### PR TITLE
Fix "make install" and "make uninstall" for distribution

### DIFF
--- a/de.persosim.driver.linux/Makefile
+++ b/de.persosim.driver.linux/Makefile
@@ -24,12 +24,14 @@ clean:
 	rm -f *.o $(LIBNAME) $(DEPENDFILE) *Test
 
 install: $(LIBNAME)
-	sudo cp reader.conf /etc/reader.conf.d/persoSim
-	sudo cp $(LIBNAME) /usr/lib/pcsc/drivers/serial/
+	mkdir -p $(PREFIX)/etc/reader.conf.d/
+	cp reader.conf $(PREFIX)/etc/reader.conf.d/persoSim
+	mkdir -p $(PREFIX)/usr/lib/pcsc/drivers/serial/
+	cp $(LIBNAME) $(PREFIX)/usr/lib/pcsc/drivers/serial/
 
 uninstall: 
-	sudo rm -f /etc/reader.conf.d/persoSim
-	sudo rm -f /usr/lib/pcsc/drivers/serial/$(LIBNAME)
+	rm -f $(PREFIX)/etc/reader.conf.d/persoSim
+	rm -f $(PREFIX)/usr/lib/pcsc/drivers/serial/$(LIBNAME)
 
 tests: hexStringTest
 


### PR DESCRIPTION
* Linux distributions requires "sudo make install" by the user
  to allow the automatic build system to create a package
  as an unprivileged user.
  So the Makefile should not use "sudo" by default.

* Add $PREFIX for "make install" to allow distribution systems
  to compile against /usr and install into a temporary package
  directory to build a distribution package.

This is used under ArchLinux:
https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=persosim_driver